### PR TITLE
Research outpost planetary ruin

### DIFF
--- a/_maps/RandomRuins/PlanetRuins/researchoutpost.dmm
+++ b/_maps/RandomRuins/PlanetRuins/researchoutpost.dmm
@@ -1,0 +1,1495 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"am" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod/light,
+/area/ruin/unpowered/research_outpost)
+"aW" = (
+/turf/open/floor/plating/asteroid/terraformable,
+/area/planet/outside)
+"bc" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on,
+/obj/effect/decal/cleanable/blood/tracks,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine,
+/area/ruin/unpowered/research_outpost)
+"br" = (
+/obj/machinery/meter{
+	target_layer = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/unpowered/research_outpost)
+"bH" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8;
+	icon_state = "scrub_map_on-3"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/unpowered/research_outpost)
+"bY" = (
+/obj/effect/decal/cleanable/blood/gibs/down,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white,
+/area/ruin/unpowered/research_outpost)
+"cj" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/broken,
+/obj/item/toy/cards/deck{
+	pixel_x = 4;
+	pixel_y = 12
+	},
+/obj/item/toy/cards/cardhand{
+	currenthand = list("2 of Diamonds","3 of Clubs");
+	pixel_x = -5
+	},
+/obj/item/reagent_containers/food/drinks/beer{
+	pixel_x = 7;
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered/research_outpost)
+"cw" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/broken,
+/obj/item/lighter{
+	pixel_x = 7;
+	pixel_y = 6
+	},
+/obj/item/storage/box/fancy/cigarettes/cigpack_robust,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered/research_outpost)
+"cK" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1;
+	icon_state = "vent_map_on-1"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered/research_outpost)
+"ea" = (
+/obj/machinery/doorButtons/access_button{
+	idDoor = "decontamination_interior";
+	idSelf = "decontam_airlock_control";
+	name = "Decontamination Access Button";
+	pixel_x = 8;
+	pixel_y = 28;
+	req_access_txt = "0"
+	},
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod/light,
+/area/ruin/unpowered/research_outpost)
+"eF" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/storage/box/donkpockets{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/item/trash/plate{
+	pixel_x = 12
+	},
+/obj/item/kitchen/fork{
+	pixel_x = 12;
+	pixel_y = 3
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/broken{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered/research_outpost)
+"eI" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered/research_outpost)
+"eM" = (
+/obj/machinery/suit_storage_unit/open,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/broken{
+	dir = 4
+	},
+/turf/open/floor/pod/light,
+/area/ruin/unpowered/research_outpost)
+"fx" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/unpowered/research_outpost)
+"gx" = (
+/obj/effect/decal/cleanable/blood/gibs/up,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/broken{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/ruin/unpowered/research_outpost)
+"gC" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod/light,
+/area/ruin/unpowered/research_outpost)
+"gW" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered/research_outpost)
+"gX" = (
+/obj/structure/table/glass,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/broken,
+/turf/open/floor/plasteel/white,
+/area/ruin/unpowered/research_outpost)
+"hN" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Recreation"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered/research_outpost)
+"iG" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Cryogenics"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/unpowered/research_outpost)
+"iZ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white,
+/area/ruin/unpowered/research_outpost)
+"kc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/broken{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/unpowered/research_outpost)
+"ki" = (
+/obj/item/shard,
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/unpowered/research_outpost)
+"kz" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered/research_outpost)
+"lF" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4;
+	icon_state = "scrub_map_on-3"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered/research_outpost)
+"lR" = (
+/obj/effect/gibspawner/generic,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/broken,
+/turf/open/floor/plasteel/white,
+/area/ruin/unpowered/research_outpost)
+"mb" = (
+/obj/machinery/atmospherics/components/unary/tank/air{
+	dir = 1;
+	piping_layer = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/unpowered/research_outpost)
+"mF" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine,
+/area/ruin/unpowered/research_outpost)
+"mX" = (
+/obj/machinery/biogenerator,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/broken,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered/research_outpost)
+"ob" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/chair/stool/bar,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered/research_outpost)
+"oi" = (
+/obj/structure/closet/cardboard,
+/obj/item/relic,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/broken{
+	dir = 1
+	},
+/obj/item/lazarus_injector,
+/turf/open/floor/plating,
+/area/ruin/unpowered/research_outpost)
+"oO" = (
+/obj/machinery/power/apc/highcap/fifteen_k{
+	pixel_y = -24
+	},
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/unpowered/research_outpost)
+"pi" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/chair/stool/bar{
+	pixel_y = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered/research_outpost)
+"qs" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/unpowered/research_outpost)
+"rq" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/machinery/portable_atmospherics/canister/bz,
+/obj/item/wrench,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white,
+/area/ruin/unpowered/research_outpost)
+"rE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/unpowered/research_outpost)
+"sq" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1;
+	icon_state = "vent_map_on-1"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/unpowered/research_outpost)
+"sv" = (
+/obj/machinery/vending/hydroseeds{
+	slogan_delay = 700
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered/research_outpost)
+"uT" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/unpowered/research_outpost)
+"vn" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered/research_outpost)
+"vX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white,
+/area/ruin/unpowered/research_outpost)
+"wD" = (
+/obj/structure/fluff/empty_cryostasis_sleeper,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white,
+/area/ruin/unpowered/research_outpost)
+"wZ" = (
+/obj/structure/closet/cardboard,
+/obj/item/artifact/easy,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/unpowered/research_outpost)
+"xW" = (
+/mob/living/simple_animal/bot/medbot/derelict,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plating,
+/area/ruin/unpowered/research_outpost)
+"ya" = (
+/obj/machinery/door/airlock/research/glass{
+	name = "Research Division"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/unpowered/research_outpost)
+"yD" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white,
+/area/ruin/unpowered/research_outpost)
+"zk" = (
+/obj/effect/decal/cleanable/glass,
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/effect/turf_decal/delivery,
+/obj/structure/door_assembly/door_assembly_research{
+	anchored = 1
+	},
+/obj/effect/decal/cleanable/blood/tracks,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/unpowered/research_outpost)
+"zO" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered/research_outpost)
+"zR" = (
+/obj/machinery/seed_extractor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered/research_outpost)
+"zZ" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered/research_outpost)
+"AO" = (
+/obj/effect/decal/cleanable/blood/tracks,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine,
+/area/ruin/unpowered/research_outpost)
+"BH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4;
+	icon_state = "vent_map_on-1"
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/unpowered/research_outpost)
+"Dk" = (
+/obj/machinery/door/airlock/maintenance_hatch,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ruin/unpowered/research_outpost)
+"Eu" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white,
+/area/ruin/unpowered/research_outpost)
+"GH" = (
+/mob/living/simple_animal/hostile/abomination/altform3,
+/obj/effect/gibspawner/generic,
+/obj/effect/decal/remains/human{
+	desc = "They look like human remains, and have clearly been gnawed at."
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white,
+/area/ruin/unpowered/research_outpost)
+"GW" = (
+/obj/machinery/vending/hydronutrients,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered/research_outpost)
+"GZ" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered/research_outpost)
+"Ha" = (
+/obj/machinery/suit_storage_unit/open,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod/light,
+/area/ruin/unpowered/research_outpost)
+"Hc" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/unpowered/research_outpost)
+"HY" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered/research_outpost)
+"IK" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/computer/arcade/orion_trail,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered/research_outpost)
+"IM" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/unpowered/research_outpost)
+"JC" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/effect/decal/cleanable/blood/tracks,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine,
+/area/ruin/unpowered/research_outpost)
+"LC" = (
+/obj/machinery/door/airlock/external/glass{
+	id_tag = "virology_airlock_interior"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/pod/light,
+/area/ruin/unpowered/research_outpost)
+"Mc" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ruin/unpowered/research_outpost)
+"Nx" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/storage/box/fancy/donut_box,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered/research_outpost)
+"OT" = (
+/obj/machinery/doorButtons/airlock_controller{
+	idExterior = "decontamination_exterior";
+	idInterior = "decontamination_interior";
+	idSelf = "decontam_airlock_control";
+	name = "Decontamination Access Console";
+	pixel_x = 8;
+	pixel_y = -22;
+	req_access_txt = "0"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white,
+/area/ruin/unpowered/research_outpost)
+"Qv" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/closet/crate,
+/obj/item/reagent_containers/food/snacks/beans,
+/obj/item/reagent_containers/food/snacks/beans,
+/obj/item/reagent_containers/food/snacks/beans,
+/obj/item/reagent_containers/food/snacks/beans,
+/obj/item/reagent_containers/glass/beaker/waterbottle/large,
+/obj/item/reagent_containers/glass/beaker/waterbottle/large,
+/obj/item/reagent_containers/glass/beaker/waterbottle/large,
+/obj/item/reagent_containers/glass/beaker/waterbottle/large,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered/research_outpost)
+"QP" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8;
+	icon_state = "vent_map_on-1"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered/research_outpost)
+"QV" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered/research_outpost)
+"Rg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/unpowered/research_outpost)
+"Rr" = (
+/obj/structure/chair/comfy/black,
+/obj/effect/gibspawner/generic,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white,
+/area/ruin/unpowered/research_outpost)
+"Rx" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered/research_outpost)
+"RD" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/blood/tracks,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/unpowered/research_outpost)
+"Sp" = (
+/turf/template_noop,
+/area/template_noop)
+"Sx" = (
+/obj/structure/table/glass,
+/obj/item/reagent_containers/glass/beaker/meta,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white,
+/area/ruin/unpowered/research_outpost)
+"Ud" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white,
+/area/ruin/unpowered/research_outpost)
+"UU" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/unpowered/research_outpost)
+"UW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered/research_outpost)
+"Ve" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/closed/wall/r_wall,
+/area/ruin/unpowered/research_outpost)
+"Vh" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer3{
+	dir = 1;
+	icon_state = "inje_map-3";
+	id = null
+	},
+/turf/open/floor/plating,
+/area/ruin/unpowered/research_outpost)
+"VH" = (
+/turf/closed/wall/r_wall,
+/area/ruin/unpowered/research_outpost)
+"VX" = (
+/obj/machinery/power/port_gen/pacman{
+	anchored = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/item/wrench,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/broken{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/unpowered/research_outpost)
+"VZ" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/broken{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered/research_outpost)
+"Wc" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white,
+/area/ruin/unpowered/research_outpost)
+"Wz" = (
+/obj/machinery/door/airlock/external/glass{
+	id_tag = "decontamination_exterior"
+	},
+/obj/machinery/doorButtons/access_button{
+	idDoor = "decontamination_exterior";
+	idSelf = "decontam_airlock_control";
+	name = "Decontamination Access Button";
+	pixel_x = -24;
+	req_access_txt = "0"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/pod/light,
+/area/ruin/unpowered/research_outpost)
+"WC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered/research_outpost)
+"WL" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white,
+/area/ruin/unpowered/research_outpost)
+"WV" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white,
+/area/ruin/unpowered/research_outpost)
+"Xa" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/unpowered/research_outpost)
+"Xp" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_y = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered/research_outpost)
+"Xq" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "Science Storage";
+	req_access_txt = "0"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/unpowered/research_outpost)
+"XG" = (
+/obj/structure/closet/crate,
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 30
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/unpowered/research_outpost)
+"Yd" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered/research_outpost)
+"Yi" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white,
+/area/ruin/unpowered/research_outpost)
+"YJ" = (
+/obj/structure/closet/cardboard,
+/obj/item/artifact/medium,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/unpowered/research_outpost)
+"YR" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Hydroponics"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered/research_outpost)
+"Za" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/closet/secure_closet/freezer{
+	locked = 0;
+	name = "fridge"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered/research_outpost)
+"Zs" = (
+/obj/machinery/chem_dispenser,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white,
+/area/ruin/unpowered/research_outpost)
+"ZC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/unpowered/research_outpost)
+
+(1,1,1) = {"
+Sp
+Sp
+Sp
+Sp
+Sp
+Sp
+Sp
+Sp
+Sp
+Sp
+Sp
+Sp
+Sp
+aW
+aW
+aW
+aW
+aW
+Sp
+Sp
+Sp
+Sp
+Sp
+"}
+(2,1,1) = {"
+Sp
+Sp
+Sp
+Sp
+Sp
+Sp
+Sp
+Sp
+aW
+aW
+aW
+aW
+aW
+aW
+aW
+aW
+aW
+aW
+Sp
+Sp
+Sp
+Sp
+Sp
+"}
+(3,1,1) = {"
+Sp
+Sp
+Sp
+Sp
+Sp
+Sp
+aW
+aW
+aW
+aW
+VH
+VH
+VH
+VH
+VH
+VH
+aW
+aW
+aW
+aW
+Sp
+Sp
+Sp
+"}
+(4,1,1) = {"
+Sp
+Sp
+Sp
+Sp
+Sp
+aW
+aW
+aW
+aW
+aW
+VH
+Xp
+Rx
+eI
+ob
+VH
+aW
+aW
+aW
+aW
+Sp
+Sp
+Sp
+"}
+(5,1,1) = {"
+Sp
+Sp
+Sp
+aW
+aW
+aW
+aW
+aW
+aW
+aW
+VH
+eF
+Rx
+ob
+cj
+VH
+aW
+aW
+aW
+aW
+aW
+Sp
+Sp
+"}
+(6,1,1) = {"
+Sp
+aW
+aW
+aW
+aW
+aW
+aW
+aW
+aW
+aW
+VH
+Nx
+Rx
+lF
+ob
+VH
+VH
+VH
+VH
+VH
+aW
+aW
+Sp
+"}
+(7,1,1) = {"
+Sp
+aW
+aW
+aW
+aW
+aW
+VH
+VH
+VH
+VH
+VH
+Za
+Rx
+vn
+cK
+VH
+XG
+IM
+UU
+Ve
+Vh
+aW
+Sp
+"}
+(8,1,1) = {"
+Sp
+aW
+aW
+aW
+aW
+aW
+VH
+Wc
+Yi
+Ud
+VH
+Qv
+Rx
+zZ
+ob
+VH
+VX
+Hc
+oO
+VH
+aW
+aW
+aW
+"}
+(9,1,1) = {"
+Sp
+aW
+VH
+VH
+VH
+VH
+VH
+rq
+yD
+lR
+VH
+IK
+pi
+zZ
+cw
+VH
+xW
+br
+mb
+VH
+aW
+aW
+aW
+"}
+(10,1,1) = {"
+Sp
+aW
+VH
+mF
+mF
+mF
+VH
+VH
+fx
+rE
+VH
+VH
+Mc
+hN
+Mc
+VH
+VH
+Dk
+VH
+VH
+VH
+VH
+aW
+"}
+(11,1,1) = {"
+Sp
+aW
+VH
+mF
+mF
+mF
+mF
+Mc
+ki
+BH
+Mc
+Ud
+Ud
+vX
+Ud
+Ud
+Ud
+OT
+VH
+ea
+gC
+VH
+aW
+"}
+(12,1,1) = {"
+Sp
+aW
+VH
+gx
+AO
+bc
+JC
+zk
+RD
+bY
+ya
+WL
+WL
+GH
+WL
+WL
+WL
+WV
+LC
+am
+am
+Wz
+aW
+"}
+(13,1,1) = {"
+Sp
+aW
+VH
+mF
+mF
+mF
+mF
+Mc
+uT
+Ud
+Mc
+kc
+Ud
+vX
+Ud
+ZC
+kc
+iZ
+VH
+Ha
+eM
+VH
+aW
+"}
+(14,1,1) = {"
+Sp
+aW
+VH
+mF
+mF
+mF
+VH
+VH
+bH
+Ud
+VH
+VH
+Mc
+YR
+Mc
+VH
+VH
+iG
+VH
+VH
+VH
+VH
+aW
+"}
+(15,1,1) = {"
+Sp
+aW
+VH
+VH
+VH
+VH
+VH
+Ud
+Ud
+Ud
+VH
+GZ
+gW
+QV
+Yd
+VH
+wD
+iZ
+wD
+VH
+aW
+aW
+aW
+"}
+(16,1,1) = {"
+Sp
+aW
+aW
+VH
+wZ
+qs
+VH
+Ud
+Ud
+Zs
+VH
+kz
+HY
+zO
+zR
+VH
+Xa
+Eu
+sq
+VH
+aW
+aW
+aW
+"}
+(17,1,1) = {"
+Sp
+aW
+aW
+VH
+oi
+qs
+Xq
+Ud
+Rr
+gX
+VH
+VZ
+HY
+zO
+mX
+VH
+wD
+kc
+wD
+VH
+aW
+aW
+Sp
+"}
+(18,1,1) = {"
+Sp
+aW
+aW
+VH
+YJ
+qs
+VH
+Ud
+Rg
+Sx
+VH
+kz
+HY
+QP
+GW
+VH
+VH
+VH
+VH
+VH
+aW
+aW
+Sp
+"}
+(19,1,1) = {"
+Sp
+aW
+aW
+VH
+VH
+VH
+VH
+VH
+VH
+VH
+VH
+kz
+UW
+WC
+sv
+VH
+aW
+aW
+aW
+aW
+aW
+aW
+Sp
+"}
+(20,1,1) = {"
+Sp
+Sp
+aW
+aW
+aW
+aW
+aW
+aW
+aW
+aW
+VH
+VH
+VH
+VH
+VH
+VH
+aW
+aW
+aW
+aW
+aW
+Sp
+Sp
+"}
+(21,1,1) = {"
+Sp
+Sp
+aW
+aW
+aW
+aW
+aW
+aW
+aW
+aW
+aW
+aW
+aW
+aW
+aW
+aW
+aW
+aW
+aW
+Sp
+Sp
+Sp
+Sp
+"}
+(22,1,1) = {"
+Sp
+Sp
+Sp
+Sp
+aW
+Sp
+Sp
+Sp
+aW
+aW
+aW
+aW
+aW
+aW
+aW
+aW
+Sp
+aW
+Sp
+Sp
+Sp
+Sp
+Sp
+"}
+(23,1,1) = {"
+Sp
+Sp
+Sp
+Sp
+Sp
+Sp
+Sp
+Sp
+Sp
+Sp
+Sp
+Sp
+Sp
+Sp
+Sp
+Sp
+Sp
+Sp
+Sp
+Sp
+Sp
+Sp
+Sp
+"}

--- a/code/datums/ruins/colony.dm
+++ b/code/datums/ruins/colony.dm
@@ -34,3 +34,11 @@
 	suffix = "monster_shrine.dmm"
 	allow_duplicates = FALSE
 	cost = 15
+
+/datum/map_template/ruin/colony/researchoutpost
+	name = "Research Outpost"
+	id = "researchoutpost"
+	description = "A old research outpost with a experiment gone wrong."
+	suffix = "researchoutpost.dmm"
+	allow_duplicates = FALSE
+	cost = 25

--- a/code/game/area/areas/ruins/planet.dm
+++ b/code/game/area/areas/ruins/planet.dm
@@ -7,3 +7,7 @@
 
 /area/ruin/unpowered/ancient_bunker_outside
 	icon_state = "red"
+
+/area/ruin/unpowered/research_outpost
+	name = "Planet Research Outpost"
+	icon_state = "dk_yellow"


### PR DESCRIPTION
Another planet ruin. It is an old research outpost with an experiment gone wrong, which kills all the scientists inside. You can get a couple artifacts, a strange object, and a lazarus injector. There is also botany machines, chem dispenser, and medibot you can grab if you want. The ruin is powered by an APC and is guarded by an abomination.

It's budget is also currently set to 25 to prevent it from loading in for now. I tried to comment it out but it made an error, so this is the best solution for now.

![researchoutpost](https://user-images.githubusercontent.com/60946370/96165524-5831f980-0ee2-11eb-8d9c-55a7752db508.PNG)
